### PR TITLE
Export fog

### DIFF
--- a/src/Debugger.cpp
+++ b/src/Debugger.cpp
@@ -1536,7 +1536,21 @@ s32 Debugger::_performSceneRip()
 			rip_v.r = v.r;
 			rip_v.g = v.g;
 			rip_v.b = v.b;
-			rip_v.a = v.a;
+
+			if ((tri.geometryMode & G_FOG) == 0) {
+				rip_v.a = v.a;
+			} else {
+				// Fog level
+				f32 f = 0.0;
+				if (v.w > 0 && v.z > 0) {
+					f = v.z / v.w * tri.fogMultiplier + tri.fogOffset;
+					if (f < 0.0)
+						f = 0.0;
+					if (f > 1.0)
+						f = 1.0;
+				}
+				rip_v.a = f;
+			}
 
 			// UV transform
 			// TODO: figure out and implement shiftScale offset

--- a/src/Debugger.h
+++ b/src/Debugger.h
@@ -169,7 +169,7 @@ private:
 
 	struct RipHeader {
 		const u8 MAGIC[6] = { 'G', 'L', '6', '4', 'R', '\0'};
-		const u16 VERSION = 2;
+		const u16 VERSION = 3;
 		char romName[20] = {0};
 		u32 num_triangles = 0;
 		u32 microcode = 0;

--- a/src/gSP.cpp
+++ b/src/gSP.cpp
@@ -840,7 +840,7 @@ void gSPTransformVertex(u32 v, SPVertex * spVtx, float mtx[4][4])
 		}
 
 		g_debugger.setValidRipModes(valid_rip_mode); // uses current rip mode
-		
+
 		if(ripMode != 34)
 		{
 			config.sceneRipper.sceneRipMode = ripMode + 1;
@@ -883,7 +883,7 @@ void gSPProcessVertex(u32 v, SPVertex * spVtx)
 
 	if (gSP.matrix.billboard)
 		gSPBillboardVertex<VNUM>(v, spVtx);
-	
+
 	gSPClipVertex<VNUM>(v, spVtx);
 
 	if (gSP.geometryMode & G_LIGHTING) {
@@ -1780,20 +1780,12 @@ void gSPLightColor( u32 lightNum, u32 packedColor )
 
 void gSPFogFactor( s16 fm, s16 fo )
 {
-	// 256 fm = 1.0 fmf
-	// 0 fm = 0.0 fmf
-	// 256 fo = 1.0 fof
-	// 0 fo = 0.0 fof
-	fm = 0;
-	fo = 0;
 	gSP.fog.multiplier = fm;
 	gSP.fog.offset = fo;
 	gSP.fog.multiplierf = _FIXED2FLOAT(fm, 8);
 	gSP.fog.offsetf = _FIXED2FLOAT(fo, 8);
 
 	gSP.changed |= CHANGED_FOGPOSITION;
-	string args = "gSPFogFactor(" + to_string(fm) + ", " + to_string(fo) + "), " + to_string(gSP.fog.multiplierf) + ", " + to_string(gSP.fog.offsetf) + "\n";
-	//dwnd().getDrawer().showMessage(args, Milliseconds(1000));
 	DebugMsg(DEBUG_NORMAL, "gSPFogFactor( %i, %i );\n", fm, fo);
 }
 


### PR DESCRIPTION
Bumps the GLR version to 3 and exports fog.  
 Companion PR in blender-import-glr is https://github.com/Luctaris/blender-import-glr/pull/9.

The first commit removes code from 0f26d1059e9641890fb131b50be75c81b100337f that removed all fog from the emulator (looks like some debugging code that got left in by accident).

The second adds export of of the fog level in the vertex alpha field. Compare with

https://github.com/Luctaris/GLideN64-SceneRipper/blob/0f26d1059e9641890fb131b50be75c81b100337f/src/Debugger.cpp#L1025-L1035

There's no binary format change, but since the meaning of that field changed, the GLR version also bumped to 3.